### PR TITLE
Simplified Raydium and Pumpfun parsers. 

### DIFF
--- a/soltxs/resolver/resolvers/pumpfun.py
+++ b/soltxs/resolver/resolvers/pumpfun.py
@@ -2,7 +2,10 @@ from dataclasses import dataclass
 from typing import List, Optional
 
 from soltxs import parser
+from soltxs.parser.parsers.pumpfun import WSOL_MINT, Swap
 from soltxs.resolver.models import Resolve, Resolver
+
+LAMPORTS_PER_SOL = 1e9
 
 
 @dataclass(slots=True)
@@ -11,20 +14,20 @@ class PumpFun(Resolve):
     Represents a resolved PumpFun transaction.
 
     Attributes:
-        type: The instruction type ('Buy' or 'Sell').
+        type: The instruction type ('buy' or 'sell').
         who: The user performing the transaction.
-        from_token: The token being sold.
-        from_amount: Amount sold (adjusted for decimals).
-        to_token: The token being bought.
-        to_amount: Amount bought (adjusted for decimals).
+        from_token: The token being exchanged from.
+        from_amount: Amount exchanged from (in SOL for SOL amounts).
+        to_token: The token being exchanged to.
+        to_amount: Amount exchanged to (in SOL for SOL amounts).
     """
 
     type: str
     who: str
     from_token: str
-    from_amount: int
+    from_amount: float
     to_token: str
-    to_amount: int
+    to_amount: float
 
 
 class _PumpFunResolver(Resolver):
@@ -40,19 +43,33 @@ class _PumpFunResolver(Resolver):
             instructions: List of parsed instructions.
 
         Returns:
-            A PumpFun resolved object if exactly one Buy/Sell instruction is found, else None.
+            A PumpFun resolved object if exactly one Swap instruction is found, else None.
         """
-        instrs = [i for i in instructions if isinstance(i, (parser.parsers.pumpfun.Buy, parser.parsers.pumpfun.Sell))]
+        instrs = [i for i in instructions if isinstance(i, Swap)]
         if len(instrs) == 1:
             instr = instrs[0]
+            if instr.is_buy:
+                p_type = "buy"
+                from_token = WSOL_MINT
+                to_token = instr.mint
+                resolved_from_amount = instr.sol_amount / LAMPORTS_PER_SOL
+                resolved_to_amount = instr.token_amount
+            else:
+                p_type = "sell"
+                from_token = instr.mint
+                to_token = WSOL_MINT
+                resolved_from_amount = instr.token_amount
+                resolved_to_amount = instr.sol_amount / LAMPORTS_PER_SOL
+
             return PumpFun(
-                type=instr.instruction_name.lower(),
-                who=instr.who,
-                from_token=instr.from_token,
-                from_amount=instr.from_token_amount / 10**instr.from_token_decimals,
-                to_token=instr.to_token,
-                to_amount=instr.to_token_amount / 10**instr.to_token_decimals,
+                type=p_type,
+                who=instr.user,
+                from_token=from_token,
+                from_amount=resolved_from_amount,
+                to_token=to_token,
+                to_amount=resolved_to_amount,
             )
+        return None
 
 
 PumpFunResolver = _PumpFunResolver()

--- a/tests/programs/test_pumpfun.py
+++ b/tests/programs/test_pumpfun.py
@@ -1,6 +1,7 @@
 from dataclasses import asdict
 
-from soltxs import normalize, parse
+from soltxs import normalize, parse, resolve
+from soltxs.parser.parsers.pumpfun import WSOL_MINT
 
 
 def test_equal_transaction(load_data):
@@ -18,7 +19,7 @@ def test_equal_transaction(load_data):
 
 def test_buy_parsing(load_data):
     """
-    Ensure PumpFun 'Buy' from Geyser or RPC yields matching parse output.
+    Ensure PumpFun 'Buy' (now parsed as a Swap) from Geyser or RPC yields matching parse output.
     """
     ge_tx = normalize(load_data("pumpfun_buy_geyser.json"))
     rpc_tx = normalize(load_data("pumpfun_buy_rpc.json"))
@@ -30,28 +31,65 @@ def test_buy_parsing(load_data):
     assert ge_parsed.signatures == rpc_parsed.signatures
     assert ge_parsed.addons == rpc_parsed.addons
 
-    # Now iterate only over the parsed instructions.
+    # Now iterate over the parsed instructions.
     for action1, action2 in zip(ge_parsed.instructions, rpc_parsed.instructions):
         d1 = asdict(action1)
         d2 = asdict(action2)
         assert d1 == d2
         if d1.get("program_name") == "PumpFun":
-            assert d1["instruction_name"] == "Buy"
-            assert d1["from_token_amount"] > 0
-            assert d1["to_token_amount"] > 0
+            assert d1["instruction_name"] == "Swap"
+            # For a buy transaction, is_buy should be True.
+            assert d1["is_buy"] is True
+            # The amounts should be greater than 0.
+            assert d1["sol_amount"] > 0
+            assert d1["token_amount"] > 0
 
 
 def test_sell_parsing(load_data):
     """
-    Confirm that a PumpFun 'Sell' transaction parse is correct.
+    Confirm that a PumpFun 'Sell' (now parsed as a Swap) transaction parse is correct.
     """
     tx = normalize(load_data("pumpfun_sell_rpc.json"))
     parsed = parse(tx)
     for action in parsed.instructions:
-        a_dict = asdict(action)
-        if a_dict.get("program_name") == "PumpFun" and a_dict.get("instruction_name") == "Sell":
-            assert a_dict["from_token_amount"] > 0
-            assert a_dict["to_token_decimals"] == 9
+        d = asdict(action)
+        if d.get("program_name") == "PumpFun" and d.get("instruction_name") == "Swap":
+            # For a sell transaction, is_buy should be False.
+            assert d["is_buy"] is False
+            assert d["sol_amount"] > 0
+            assert d["token_amount"] > 0
+
+
+def test_resolve_pumpfun_buy(load_data):
+    """
+    Ensures that resolve(...) identifies a PumpFun 'Buy' instruction.
+    """
+    tx_data = load_data("pumpfun_buy_rpc.json")
+    tx_obj = normalize(tx_data)
+    parsed = parse(tx_obj)
+    outcome = resolve(parsed)
+
+    assert outcome is not None
+    # The resolved type should be 'buy'.
+    assert outcome.type == "buy"
+    assert outcome.from_token == WSOL_MINT
+    assert outcome.from_amount > 0
+
+
+def test_resolve_pumpfun_sell(load_data):
+    """
+    Ensures that resolve(...) identifies a PumpFun 'Sell' instruction.
+    """
+    tx_data = load_data("pumpfun_sell_rpc.json")
+    tx_obj = normalize(tx_data)
+    parsed = parse(tx_obj)
+    outcome = resolve(parsed)
+
+    assert outcome is not None
+    # The resolved type should be 'sell'.
+    assert outcome.type == "sell"
+    assert outcome.to_token == WSOL_MINT
+    assert outcome.to_amount > 0
 
 
 def test_create_parsing(load_data):
@@ -61,8 +99,8 @@ def test_create_parsing(load_data):
     tx = normalize(load_data("pumpfun_create_rpc.json"))
     parsed = parse(tx)
     for action in parsed.instructions:
-        a_dict = asdict(action)
-        if a_dict.get("program_name") == "PumpFun" and a_dict.get("instruction_name") == "Create":
-            assert a_dict["mint"] is not None
-            assert a_dict["name"] != ""
-            assert a_dict["symbol"] != ""
+        d = asdict(action)
+        if d.get("program_name") == "PumpFun" and d.get("instruction_name") == "Create":
+            assert d["mint"] is not None
+            assert d["name"] != ""
+            assert d["symbol"] != ""


### PR DESCRIPTION
Changes:
* Replaced `Buy` and `Sell` Pumpfun instruction for simpler (and correct) `Swap`.
* Updated Pumpfun resolver to be closer to Raydium.
* Updated Raydium resolver to use SOL instead of lamports when reporting SOL amounts.
